### PR TITLE
remove ssl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
 dbdata
-couchdb.crt
-couchdb.key

--- a/README.md
+++ b/README.md
@@ -1,32 +1,16 @@
 # couchdb-docker
 
-This repo includes a docker-compose file that sets up a basic couchdb instance with a CORs-enabled configuration.
+This repo includes a `docker-compose` file that sets up a basic couchdb instance with a CORs-enabled configuration. It's to be used on your LAN and uses `http` instead of `https` because of this.
 
-This is made specifically to be the database server for [Notes](https://github.com/ste163/notes).
+This `docker-compose` is made specifically to be the database server for [Notes](https://github.com/ste163/notes).
 
-## Setup
-
-This setup was done on Fedora Linux and has not been tested on any other operating system.
+## Setup (MacOS, Fedora Linux)
 
 ### Requirements
 
-- Any computer that supports docker
+- Device that supports docker
 - Install [docker-compose](https://github.com/docker/compose)
-- `git clone` the project
-
-### Creating SSL certificates (optional)
-
-TODO: once `notes` is released with the Tauri builds, I need to revisit whether to support `HTTPS` at all. It only somewhat works for browsers with hacky manual steps of approving the "unsafe" connection. The Tauri builds do not appear to have this issue because they are not hosted over `HTTPS`.
-
-> There is a problem with this approach. If you access this container through a web browser, you will have to accept the risk of this being a non-CA certificate (the browser will warn this is unsafe, which it is in other circumstances). This is totally fine because this runs only on your LAN.
-
-Because this container is running as a host for other devices to connect to, we need to setup HTTPS.
-
-This container is designed to be running over your LAN, so we'll be creating a certificate with a very long expiration date.
-
-```bash
-openssl req -newkey rsa:2048 -nodes -keyout couchdb.key -x509 -days 36500 -out couchdb.crt
-```
+- `git clone` this project
 
 ### Running the container
 
@@ -37,13 +21,13 @@ docker compose up
 ```
 
 2. Once the container is running, find your local IP address:
-   Typically, your local IP address will be the one that starts with `192.168.*` or `10.*`. It's usually the first `inet` line that doesn't start with `127.0.0.1`.
+   Typically, your local IP address will be the one that starts with `192.168.*`. It's usually the first `inet` line that doesn't start with `127.0.0.1`.
 
 ```bash
 ifconfig | grep inet
 ```
 
-Note: this is not a static IP address for the device running the container, so this address may change when the device restarts.
+Note: this is not a static IP address for the device running the container, so this address may change.
 
 ## Connecting to the container
 
@@ -51,4 +35,4 @@ The admin user and password are defined in the `docker-compose.yaml`. Because th
 
 ### Database management (GUI)
 
-To interact with the CouchDB server and database GUI while running the container, go to: `http://localhost:5984/_utils/`.
+To interact with the CouchDB server and database GUI while running the container, go to: `http://localhost:5984/_utils/`. Alternatively, you can use `{your IP address}:5984/_utils/`

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   couchserver:
-    image: couchdb:3.3.2
+    image: couchdb:3.4.2
     restart: always
     ports:
       - "5984:5984"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,6 @@ services:
     restart: always
     ports:
       - "5984:5984"
-      - "6984:6984"
     networks:
       - localnetwork
     environment:
@@ -14,8 +13,6 @@ services:
     volumes:
       - ./dbdata:/opt/couchdb/data
       - ./local.ini:/opt/couchdb/etc/local.d/local.ini
-      - ./couchdb.crt:/opt/couchdb/etc/cert/couchdb.crt
-      - ./couchdb.key:/opt/couchdb/etc/cert/couchdb.key
 
 networks:
   localnetwork:

--- a/local.ini
+++ b/local.ini
@@ -10,9 +10,3 @@ origins = *
 credentials = true
 methods = GET, PUT, POST, HEAD, DELETE, OPTIONS
 headers = accept, authorization, content-type, origin, referer, x-csrf-token
-
-[ssl]
-enable = true
-cert_file = /opt/couchdb/etc/cert/couchdb.crt
-key_file = /opt/couchdb/etc/cert/couchdb.key
-port = 6984


### PR DESCRIPTION
- Removed references to SSL, HTTPS, and connecting to the browser
- This is specifically setup for the installed Notes application and not the browser version
- Updated to latest version of the image